### PR TITLE
Additional fix for 32-bit systems.

### DIFF
--- a/src/sequence.cxx
+++ b/src/sequence.cxx
@@ -34,10 +34,10 @@ using saidx64_t = saidx64_t;
 sequence::sequence(std::string name_, std::string nucl_) noexcept
 	: name{std::move(name_)}, nucl{std::move(nucl_)}, length{nucl.size()}
 {
-	const size_t LENGTH_LIMIT = (size_t)1 << (sizeof(saidx64_t) * CHAR_BIT - 2);
+	const unsigned long long int LENGTH_LIMIT = (unsigned long long int)1 << (sizeof(saidx64_t) * CHAR_BIT - 2);
 	if (this->size() > LENGTH_LIMIT) {
 		errx(1,
-			 "The input sequence %s is too long. The technical limit is %zu.",
+			 "The input sequence %s is too long. The technical limit is %llu.",
 			 this->name.c_str(), LENGTH_LIMIT);
 	}
 }


### PR DESCRIPTION
Thank you for https://github.com/EvolBioInf/phylonium/commit/a47612628b2b2c8366d2df98f5da527849ab544a ; I had to add the contents of this PR as well to fix the 32-bit builds of Phylonium for Debian.

Possibly this was also needed because we define `-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -D_TIME_BITS=64` on armel/armhf?